### PR TITLE
Removed building tools from NGINX image

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -5,13 +5,15 @@ FROM centos:centos7
 MAINTAINER Lorenzo Fontana, fontanalorenzo@me.com
 
 WORKDIR /tmp
-RUN yum install -y install gcc gcc-c++ make zlib-devel pcre-devel openssl-devel wget telnet tar \
+RUN yum install -y gcc gcc-c++ make zlib pcre openssl zlib-devel pcre-devel openssl-devel wget telnet tar \
     && wget -nv -O - http://nginx.org/download/nginx-VERSION.tar.gz | tar zx \
     && cd nginx-VERSION \
     && CONFIGURE_COMMAND \
     && make -j \
     && make install \ 
-    && rm -Rf /tmp/nginx*
+    && rm -Rf /tmp/nginx* \
+    && yum remove -y gcc gcc-c++ make zlib-devel pcre-devel openssl-devel wget telnet tar \
+    && yum clean all 
 
 WORKDIR /
 


### PR DESCRIPTION
The image size is down to 360 MB (quasi 100MB less than before).
